### PR TITLE
Switch anthropic samples to Qwen3 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Anthropic Cookbook
 
-The Anthropic Cookbook provides code and guides designed to help developers build with Claude, offering copy-able code snippets that you can easily integrate into your own projects.
+The Anthropic Cookbook provides code and guides designed to help developers build with Claude, offering copy-able code snippets that you can easily integrate into your own projects. This fork demonstrates using the Qwen3 API via the OpenAI compatible endpoint.
 
 ## Prerequisites
 
-To make the most of the examples in this cookbook, you'll need an Anthropic API key (sign up for free [here](https://www.anthropic.com)).
+To make the most of the examples in this cookbook, you'll need a DashScope API key for Qwen3. Set it in the environment variable `DASHSCOPE_API_KEY`.
 
-While the code examples are primarily written in Python, the concepts can be adapted to any programming language that supports interaction with the Anthropic API.
+While the code examples are primarily written in Python, the concepts can be adapted to any programming language that supports interaction with the OpenAI compatible API.
 
-If you're new to working with the Anthropic API, we recommend starting with our [Anthropic API Fundamentals course](https://github.com/anthropics/courses/tree/master/anthropic_api_fundamentals) to get a solid foundation.
+If you're new to working with Qwen3, refer to the [DashScope documentation](https://help.aliyun.com/zh/dashscope/) for a solid foundation.
 
 ## Explore Further
 

--- a/patterns/agents/util.py
+++ b/patterns/agents/util.py
@@ -1,8 +1,11 @@
-from anthropic import Anthropic
+from openai import OpenAI
 import os
 import re
 
-client = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+client = OpenAI(
+    api_key=os.getenv("DASHSCOPE_API_KEY"),
+    base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+)
 
 def llm_call(prompt: str, system_prompt: str = "", model="claude-3-5-sonnet-20241022") -> str:
     """
@@ -16,16 +19,20 @@ def llm_call(prompt: str, system_prompt: str = "", model="claude-3-5-sonnet-2024
     Returns:
         str: The response from the language model.
     """
-    client = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
-    messages = [{"role": "user", "content": prompt}]
-    response = client.messages.create(
+    client = OpenAI(
+        api_key=os.getenv("DASHSCOPE_API_KEY"),
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+    )
+    response = client.chat.completions.create(
         model=model,
         max_tokens=4096,
-        system=system_prompt,
-        messages=messages,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ],
         temperature=0.1,
     )
-    return response.content[0].text
+    return response.choices[0].message.content
 
 def extract_xml(text: str, tag: str) -> str:
     """

--- a/skills/retrieval_augmented_generation/evaluation/eval_end_to_end.py
+++ b/skills/retrieval_augmented_generation/evaluation/eval_end_to_end.py
@@ -1,5 +1,5 @@
 from typing import Dict, Union, Any, List
-from anthropic import Anthropic
+from openai import OpenAI
 import re
 import os
 import xml.etree.ElementTree as ET
@@ -32,20 +32,23 @@ def evaluate_end_to_end(query, generated_answer, correct_answer):
     </evaluation>
     """
     
-    client = Anthropic(api_key=os.environ.get('ANTHROPIC_API_KEY'))
+    client = OpenAI(
+        api_key=os.getenv('DASHSCOPE_API_KEY'),
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+    )
     try:
-        response = client.messages.create(
-            model="claude-3-5-sonnet-20241022",
+        response = client.chat.completions.create(
+            model="qwen-plus",
             max_tokens=1500,
             messages=[
                 {"role": "user", "content": prompt},
-                {"role": "assistant", "content": "<evaluation>"}
+                {"role": "assistant", "content": "<evaluation>"},
             ],
             temperature=0,
-            stop_sequences=["</evaluation>"]
+            stop=["</evaluation>"]
         )
-        
-        response_text = response.content[0].text
+
+        response_text = response.choices[0].message.content
 
         # Use regex to extract explanation and is_correct
         explanation_match = re.search(r'<explanation>(.*?)</explanation>', response_text, re.DOTALL)

--- a/skills/retrieval_augmented_generation/evaluation/provider_retrieval.py
+++ b/skills/retrieval_augmented_generation/evaluation/provider_retrieval.py
@@ -2,7 +2,7 @@ import json
 import os
 from typing import Callable, List, Dict, Any, Tuple, Set
 from vectordb import VectorDB, SummaryIndexedVectorDB
-from anthropic import Anthropic
+from openai import OpenAI
 
 # Initialize the VectorDB
 db = VectorDB("anthropic_docs")
@@ -64,18 +64,24 @@ def _rerank_results(query: str, results: List[Dict], k: int = 3) -> List[Dict]:
     <relevant_indices>put the numbers of your indices here, seeparted by commas</relevant_indices>
     """
     
-    client = Anthropic(api_key=os.environ.get('ANTHROPIC_API_KEY'))
+    client = OpenAI(
+        api_key=os.getenv('DASHSCOPE_API_KEY'),
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+    )
     try:
-        response = client.messages.create(
-            model="claude-3-5-sonnet-20241022",
+        response = client.chat.completions.create(
+            model="qwen-plus",
             max_tokens=50,
-            messages=[{"role": "user", "content": prompt}, {"role": "assistant", "content": "<relevant_indices>"}],
+            messages=[
+                {"role": "user", "content": prompt},
+                {"role": "assistant", "content": "<relevant_indices>"},
+            ],
             temperature=0,
-            stop_sequences=["</relevant_indices>"]
+            stop=["</relevant_indices>"]
         )
         
         # Extract the indices from the response
-        response_text = response.content[0].text.strip()
+        response_text = response.choices[0].message.content.strip()
         indices_str = response_text
         relevant_indices = []
         for idx in indices_str.split(','):


### PR DESCRIPTION
## Summary
- switch python utilities from the Anthropic SDK to Qwen3 via OpenAI compatible API
- update README to reference DashScope API key

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fb5fef5988323921bc48219c9d998